### PR TITLE
update documentation to use the latest speclj version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,12 +2,12 @@
   :description "Speclj's Documentation Website"
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [joodo "2.0.0"]
-                 [speclj "2.9.1"]]
-  :dev-dependencies [[speclj "2.9.1"]]
+                 [speclj "3.1.0"]]
+  :dev-dependencies [[speclj "3.1.0"]]
   :test-paths ["spec/"]
   :java-source-paths ["src/"]
   :min-lein-version "2.0.0"
-  :plugins [[speclj "2.9.1"]
+  :plugins [[speclj "3.1.0"]
             [lein-ring "0.8.8"]]
   :ring {:handler speclj_www.core/app}
   )

--- a/src/speclj_www/view/install.hiccup
+++ b/src/speclj_www/view/install.hiccup
@@ -8,8 +8,8 @@
  [:ul
   [:li "Include speclj in your :profile, :plugins and add \"spec\" to the :test-paths array.
    <pre><code>
-    :profiles {:dev {:dependencies [[speclj \"2.5.0\"]]}}
-    :plugins [[speclj \"2.5.0\"]]
+    :profiles {:dev {:dependencies [[speclj \"3.1.0\"]]}}
+    :plugins [[speclj \"3.1.0\"]]
     :test-paths [\"spec\"]</code></pre>"]
   [:br]
   [:li "Leiningen will download Speclj the first time you run a spec."]]
@@ -40,8 +40,8 @@
  [:ul
   [:li "Include speclj in your <b>:profile</b> and <b>:plugins</b>:
    <pre><code>
-    :profiles {:dev {:dependencies [[speclj \"2.5.0\"]]}}
-    :plugins [[speclj \"2.5.0\"]]
+    :profiles {:dev {:dependencies [[speclj \"3.1.0\"]]}}
+    :plugins [[speclj \"3.1.0\"]]
     :test-paths [\"spec\"]
   </code></pre>"]
   [:br]


### PR DESCRIPTION
Speclj 3.1.0 from Clojars has more extensive docstrings for some of the macros, especially for `should-have-invoked`. Is now a good time to update the version used to build specljweb -- plus bump the versions in the installation guide?
